### PR TITLE
fixes "many" (and once) to return promise

### DIFF
--- a/lib/ChainedEventEmitter.js
+++ b/lib/ChainedEventEmitter.js
@@ -235,7 +235,7 @@
       if (--ttl === 0) {
         self.off(event, listener);
       }
-      fn.apply(this, arguments);
+      return fn.apply(this, arguments);
     };
 
     listener._origin = fn;


### PR DESCRIPTION
Any promise returned from handler was getting lost in the wrapper created by "many".
